### PR TITLE
Update SapMachine URL to https://sapmachine.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![REUSE status](https://api.reuse.software/badge/github.com/SAP/sapmachine-manager-for-macos)](https://api.reuse.software/info/github.com/SAP/sapmachine-manager-for-macos)
 
-_SapMachine Manager_ is a handy and easy-to-use tool allowing Mac users to easily install, uninstall, manage, and automatically update one or more instances of [SapMachine](https://sap.github.io/SapMachine/) on a Mac. SapMachine is a version of OpenJDK maintained and supported by _SAP_. Additionally, the app supports the creation of SapMachine installer packages for macOS and the definition of the default Java environment. _SapMachine Manager_ can be deployed and managed via MDM. 
+_SapMachine Manager_ is a handy and easy-to-use tool allowing Mac users to easily install, uninstall, manage, and automatically update one or more instances of [SapMachine](https://sapmachine.io/) on a Mac. SapMachine is a version of OpenJDK maintained and supported by _SAP_. Additionally, the app supports the creation of SapMachine installer packages for macOS and the definition of the default Java environment. _SapMachine Manager_ can be deployed and managed via MDM. 
 
 _SapMachine Manager_ is the standard tool within SAP to install SapMachine on macOS. 
 

--- a/source/Shared/Constants.h
+++ b/source/Shared/Constants.h
@@ -18,7 +18,7 @@
 #define kMTJavaHomePath                     @"/usr/libexec/java_home"
 #define kMTUnarchiverPath                   @"/usr/bin/tar"
 #define kMTJVMFolderPath                    @"/Library/Java/JavaVirtualMachines"
-#define kMTSapMachineReleasesURL            @"https://sap.github.io/SapMachine/assets/data/sapmachine-releases-latest.json"
+#define kMTSapMachineReleasesURL            @"https://sapmachine.io/assets/data/sapmachine-releases-latest.json"
 #define kMTGitHubURL                        @"https://github.com/SAP/sapmachine-manager-for-macos"
 #define kMTSapMachineWebsiteURL             @"https://sapmachine.io/"
 #define kMTErrorDomain                      @"corp.sap.SapMachineManager.ErrorDomain"


### PR DESCRIPTION
We want to remove the old URL https://sap.github.io/SapMachine/ in the future so all usages of it have to be changed to https://sapmachine.io/